### PR TITLE
[feat] 카테고리 조회 및 식사량 기록 

### DIFF
--- a/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
+++ b/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
@@ -1,0 +1,25 @@
+package com.eat.eat_server.logs.conrtoller;
+
+import com.eat.eat_server.logs.dto.LogRequestDto;
+import com.eat.eat_server.logs.dto.LogResponseDto;
+import com.eat.eat_server.logs.service.LogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LogController {
+
+    private final LogService logService;
+
+    @PostMapping("/categories/{categoryId}")
+    public ResponseEntity<LogResponseDto> createLog(@PathVariable Long categoryId,
+                                                    @RequestBody LogRequestDto logRequestDto) {
+        LogResponseDto logResponseDto = logService.createLog(categoryId, logRequestDto);
+        return ResponseEntity.ok(logResponseDto);
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
+++ b/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
@@ -5,10 +5,7 @@ import com.eat.eat_server.logs.dto.LogResponseDto;
 import com.eat.eat_server.logs.service.LogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
+++ b/src/main/java/com/eat/eat_server/logs/conrtoller/LogController.java
@@ -2,21 +2,32 @@ package com.eat.eat_server.logs.conrtoller;
 
 import com.eat.eat_server.logs.dto.LogRequestDto;
 import com.eat.eat_server.logs.dto.LogResponseDto;
+import com.eat.eat_server.logs.dto.SubCategoryResponseDto;
+import com.eat.eat_server.logs.service.CategoryService;
 import com.eat.eat_server.logs.service.LogService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class LogController {
 
     private final LogService logService;
+    private final CategoryService categoryService;
 
     @PostMapping("/categories/{categoryId}")
     public ResponseEntity<LogResponseDto> createLog(@PathVariable Long categoryId,
                                                     @RequestBody LogRequestDto logRequestDto) {
         LogResponseDto logResponseDto = logService.createLog(categoryId, logRequestDto);
         return ResponseEntity.ok(logResponseDto);
+    }
+
+    @GetMapping("/categories/{categoryId}")
+    public ResponseEntity<List<SubCategoryResponseDto>> findSubCategories(@PathVariable Long categoryId) {
+        List<SubCategoryResponseDto> subCategoryResponseDtos = categoryService.findSubCategories(categoryId);
+        return ResponseEntity.ok(subCategoryResponseDtos);
     }
 }

--- a/src/main/java/com/eat/eat_server/logs/domain/Category.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/Category.java
@@ -1,0 +1,19 @@
+package com.eat.eat_server.logs.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/com/eat/eat_server/logs/domain/Category.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/Category.java
@@ -12,7 +12,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
-    private Long id;
+    private long id;
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/eat/eat_server/logs/domain/Log.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/Log.java
@@ -14,20 +14,39 @@ public class Log {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "log_id")
-    private Long id;
+    private long id;
 
     @ManyToOne
     @JoinColumn(name = "subcategory_id")
     private SubCategory subCategory;
 
-    @Column
+    @Column(nullable = false)
     private String menu;
 
-    @Column
-    private Double intake;
+    @Column(nullable = false)
+    private double intake;
+
+    @Column(nullable = false)
+    private String unit;
+
+
+    @Column(nullable = false)
+    private int level;
 
     @Column
-    private String unit;
+    private int calorie;
+
+    @Column
+    private double fat;
+
+    @Column
+    private double protein;
+
+    @Column
+    private double carbs;
+
+    @Column
+    private double sugar;
 
     @Column
     private String memo;
@@ -36,13 +55,26 @@ public class Log {
     private Log(
             SubCategory subCategory,
             String menu,
-            Double intake,
+            double intake,
             String unit,
-            String memo) {
+            int level,
+            int calorie,
+            double fat,
+            double protein,
+            double carbs,
+            double sugar,
+            String memo
+            ) {
         this.subCategory = subCategory;
         this.menu = menu;
         this.intake = intake;
         this.unit = unit;
+        this.level = level;
+        this.calorie = calorie;
+        this.fat = fat;
+        this.protein = protein;
+        this.carbs = carbs;
+        this.sugar = sugar;
         this.memo = memo;
     }
 
@@ -52,6 +84,12 @@ public class Log {
                 .menu(logRequestDto.getMenu())
                 .intake(logRequestDto.getIntake())
                 .unit(logRequestDto.getUnit())
+                .level(logRequestDto.getLevel())
+                .calorie(logRequestDto.getCalorie())
+                .fat(logRequestDto.getFat())
+                .protein(logRequestDto.getProtein())
+                .carbs(logRequestDto.getCarbs())
+                .sugar(logRequestDto.getSugar())
                 .memo(logRequestDto.getMemo())
                 .build();
     }

--- a/src/main/java/com/eat/eat_server/logs/domain/Log.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/Log.java
@@ -1,0 +1,58 @@
+package com.eat.eat_server.logs.domain;
+
+import jakarta.persistence.*;
+import com.eat.eat_server.logs.dto.LogRequestDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Log {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "subcategory_id")
+    private SubCategory subCategory;
+
+    @Column
+    private String menu;
+
+    @Column
+    private Double intake;
+
+    @Column
+    private String unit;
+
+    @Column
+    private String memo;
+
+    @Builder
+    private Log(
+            SubCategory subCategory,
+            String menu,
+            Double intake,
+            String unit,
+            String memo) {
+        this.subCategory = subCategory;
+        this.menu = menu;
+        this.intake = intake;
+        this.unit = unit;
+        this.memo = memo;
+    }
+
+    public static Log of(SubCategory subCategory, LogRequestDto logRequestDto) {
+        return Log.builder()
+                .subCategory(subCategory)
+                .menu(logRequestDto.getMenu())
+                .intake(logRequestDto.getIntake())
+                .unit(logRequestDto.getUnit())
+                .memo(logRequestDto.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/domain/SubCategory.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/SubCategory.java
@@ -1,0 +1,37 @@
+package com.eat.eat_server.logs.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class SubCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subcategory_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Builder
+    private SubCategory(Category category, String name) {
+        this.category = category;
+        this.name = name;
+    }
+
+    public static SubCategory of(Category category, String name) {
+        return SubCategory.builder()
+                .category(category)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/domain/SubCategory.java
+++ b/src/main/java/com/eat/eat_server/logs/domain/SubCategory.java
@@ -13,7 +13,7 @@ public class SubCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "subcategory_id")
-    private Long id;
+    private long id;
 
     @ManyToOne
     @JoinColumn(name = "category_id")

--- a/src/main/java/com/eat/eat_server/logs/dto/LogRequestDto.java
+++ b/src/main/java/com/eat/eat_server/logs/dto/LogRequestDto.java
@@ -9,7 +9,13 @@ public class LogRequestDto {
 
     private final String subCategory;
     private final String menu;
-    private final Double intake;
+    private final double intake;
     private final String unit;
+    private final int level;
+    private final int calorie;
+    private final double fat;
+    private final double protein;
+    private final double carbs;
+    private final double sugar;
     private final String memo;
 }

--- a/src/main/java/com/eat/eat_server/logs/dto/LogRequestDto.java
+++ b/src/main/java/com/eat/eat_server/logs/dto/LogRequestDto.java
@@ -1,0 +1,15 @@
+package com.eat.eat_server.logs.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LogRequestDto {
+
+    private final String subCategory;
+    private final String menu;
+    private final Double intake;
+    private final String unit;
+    private final String memo;
+}

--- a/src/main/java/com/eat/eat_server/logs/dto/LogResponseDto.java
+++ b/src/main/java/com/eat/eat_server/logs/dto/LogResponseDto.java
@@ -6,12 +6,13 @@ import lombok.Getter;
 
 @Getter
 public class LogResponseDto {
-    private final Long id;
+
+    private final long id;
     private final String subCategory;
     private final String menu;
 
     @Builder
-    private LogResponseDto(Long id,
+    private LogResponseDto(long id,
                            String subCategory,
                            String menu) {
         this.id = id;

--- a/src/main/java/com/eat/eat_server/logs/dto/LogResponseDto.java
+++ b/src/main/java/com/eat/eat_server/logs/dto/LogResponseDto.java
@@ -1,0 +1,29 @@
+package com.eat.eat_server.logs.dto;
+
+import com.eat.eat_server.logs.domain.Log;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LogResponseDto {
+    private final Long id;
+    private final String subCategory;
+    private final String menu;
+
+    @Builder
+    private LogResponseDto(Long id,
+                           String subCategory,
+                           String menu) {
+        this.id = id;
+        this.subCategory = subCategory;
+        this.menu = menu;
+    }
+
+    public static LogResponseDto from(Log log) {
+        return LogResponseDto.builder()
+                .id(log.getId())
+                .subCategory(log.getSubCategory().getName())
+                .menu(log.getMenu())
+                .build();
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/dto/SubCategoryResponseDto.java
+++ b/src/main/java/com/eat/eat_server/logs/dto/SubCategoryResponseDto.java
@@ -1,0 +1,25 @@
+package com.eat.eat_server.logs.dto;
+
+import com.eat.eat_server.logs.domain.SubCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SubCategoryResponseDto {
+
+    private long id;
+    private String name;
+
+    @Builder
+    private SubCategoryResponseDto(long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static SubCategoryResponseDto from(SubCategory subCategory) {
+        return SubCategoryResponseDto.builder()
+                .id(subCategory.getId())
+                .name(subCategory.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/repository/CategoryRepository.java
+++ b/src/main/java/com/eat/eat_server/logs/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.eat.eat_server.logs.repository;
+
+import com.eat.eat_server.logs.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findById(Long id);
+}

--- a/src/main/java/com/eat/eat_server/logs/repository/LogRepository.java
+++ b/src/main/java/com/eat/eat_server/logs/repository/LogRepository.java
@@ -1,0 +1,8 @@
+package com.eat.eat_server.logs.repository;
+
+import com.eat.eat_server.logs.domain.Log;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface LogRepository extends JpaRepository<Log, Long> {
+}

--- a/src/main/java/com/eat/eat_server/logs/repository/SubCategoryRepository.java
+++ b/src/main/java/com/eat/eat_server/logs/repository/SubCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.eat.eat_server.logs.repository;
+
+import com.eat.eat_server.logs.domain.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
+
+    SubCategory findByName(String name);
+    Boolean existsByName(String name);
+}

--- a/src/main/java/com/eat/eat_server/logs/repository/SubCategoryRepository.java
+++ b/src/main/java/com/eat/eat_server/logs/repository/SubCategoryRepository.java
@@ -3,9 +3,12 @@ package com.eat.eat_server.logs.repository;
 import com.eat.eat_server.logs.domain.SubCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
 
     SubCategory findByName(String name);
     Boolean existsByName(String name);
+    List<SubCategory> findByCategoryId(long categoryId);
 }

--- a/src/main/java/com/eat/eat_server/logs/service/CategoryService.java
+++ b/src/main/java/com/eat/eat_server/logs/service/CategoryService.java
@@ -1,0 +1,24 @@
+package com.eat.eat_server.logs.service;
+
+import com.eat.eat_server.logs.domain.SubCategory;
+import com.eat.eat_server.logs.dto.SubCategoryResponseDto;
+import com.eat.eat_server.logs.repository.SubCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final SubCategoryRepository subCategoryRepository;
+
+    public List<SubCategoryResponseDto> findSubCategories(Long categoryId) {
+        List<SubCategory> subCategories = subCategoryRepository.findAll();
+        return subCategories.stream()
+                .map(SubCategoryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/service/CategoryService.java
+++ b/src/main/java/com/eat/eat_server/logs/service/CategoryService.java
@@ -16,7 +16,7 @@ public class CategoryService {
     private final SubCategoryRepository subCategoryRepository;
 
     public List<SubCategoryResponseDto> findSubCategories(Long categoryId) {
-        List<SubCategory> subCategories = subCategoryRepository.findAll();
+        List<SubCategory> subCategories = subCategoryRepository.findByCategoryId(categoryId);
         return subCategories.stream()
                 .map(SubCategoryResponseDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/eat/eat_server/logs/service/LogService.java
+++ b/src/main/java/com/eat/eat_server/logs/service/LogService.java
@@ -1,0 +1,37 @@
+package com.eat.eat_server.logs.service;
+
+import com.eat.eat_server.logs.domain.Category;
+import com.eat.eat_server.logs.domain.Log;
+import com.eat.eat_server.logs.domain.SubCategory;
+import com.eat.eat_server.logs.dto.LogRequestDto;
+import com.eat.eat_server.logs.dto.LogResponseDto;
+import com.eat.eat_server.logs.repository.CategoryRepository;
+import com.eat.eat_server.logs.repository.LogRepository;
+import com.eat.eat_server.logs.repository.SubCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class LogService {
+
+    private final LogRepository logRepository;
+    private final SubCategoryRepository subCategoryRepository;
+    private final CategoryRepository categoryRepository;
+
+    private SubCategory getOrCreateSubCategory(Long categoryId, String name) {
+        if (subCategoryRepository.existsByName(name)) {
+            return subCategoryRepository.findByName(name);
+        }
+        Category category = categoryRepository.findById(categoryId).orElseThrow();
+        return subCategoryRepository.save(SubCategory.of(category, name));
+    }
+
+    public LogResponseDto createLog(Long categoryId, LogRequestDto logRequestDto) {
+        String subCategoryName = logRequestDto.getSubCategory();
+        SubCategory subCategory = getOrCreateSubCategory(categoryId, subCategoryName);
+        Log log = logRepository.save(Log.of(subCategory, logRequestDto));
+        return LogResponseDto.from(log);
+    }
+}

--- a/src/main/java/com/eat/eat_server/logs/service/LogService.java
+++ b/src/main/java/com/eat/eat_server/logs/service/LogService.java
@@ -11,7 +11,6 @@ import com.eat.eat_server.logs.repository.SubCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-
 @Service
 @RequiredArgsConstructor
 public class LogService {


### PR DESCRIPTION
close #3 

- 카테고리, 하위카테고리, 로그 테이블 생성
- 상위 카테고리 내 하위 카테고리 목록 조회 API 구현
- 식사량 기록 API 구현
- 유저 도메인 완료 후 식사 로그에 유저 모델 연결 필요
- 추후 baseentity 상속하여 생성일자 저장 자동화 필요
