### PR TITLE
[feat] 캘린더 로그 조회, 특정 메뉴 로그 검색

### DIFF
--- a/src/main/java/com/eat/eat_server/domain/logs/conrtoller/LogController.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/conrtoller/LogController.java
@@ -1,9 +1,6 @@
 package com.eat.eat_server.domain.logs.conrtoller;
 
-import com.eat.eat_server.domain.logs.dto.LogRequestDto;
-import com.eat.eat_server.domain.logs.dto.LogResponseDto;
-import com.eat.eat_server.domain.logs.dto.ProperAmountDto;
-import com.eat.eat_server.domain.logs.dto.SubCategoryResponseDto;
+import com.eat.eat_server.domain.logs.dto.*;
 import com.eat.eat_server.domain.logs.service.CategoryService;
 import com.eat.eat_server.domain.logs.service.LogService;
 import com.eat.eat_server.domain.logs.service.ProperService;
@@ -43,6 +40,12 @@ public class LogController {
                                                          @RequestParam(required=false) Long subCategoryId) {
         List<LogResponseDto> logResponseDtos = logService.findLogs(user, subCategoryId);
         return ResponseEntity.ok(logResponseDtos);
+    }
+
+    @GetMapping("/calender")
+    public ResponseEntity<List<CalenderLogDto>> findCalenderLogs(@AuthenticationPrincipal User user) {
+        List<CalenderLogDto> calenderLogDtos = logService.findCalenderLogs(user);
+        return ResponseEntity.ok(calenderLogDtos);
     }
 
     @GetMapping("/proper")

--- a/src/main/java/com/eat/eat_server/domain/logs/conrtoller/LogController.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/conrtoller/LogController.java
@@ -42,6 +42,13 @@ public class LogController {
         return ResponseEntity.ok(logResponseDtos);
     }
 
+    @GetMapping("/logs/search")
+    public ResponseEntity<List<LogResponseDto>> findLogsByMenu(@AuthenticationPrincipal User user,
+                                                         @RequestParam(required=true) String menu) {
+        List<LogResponseDto> logResponseDtos = logService.findLogsByMenu(user, menu);
+        return ResponseEntity.ok(logResponseDtos);
+    }
+
     @GetMapping("/calender")
     public ResponseEntity<List<CalenderLogDto>> findCalenderLogs(@AuthenticationPrincipal User user) {
         List<CalenderLogDto> calenderLogDtos = logService.findCalenderLogs(user);

--- a/src/main/java/com/eat/eat_server/domain/logs/dto/CalenderLogDto.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/dto/CalenderLogDto.java
@@ -1,0 +1,54 @@
+package com.eat.eat_server.domain.logs.dto;
+
+import com.eat.eat_server.domain.logs.domain.Level;
+import com.eat.eat_server.domain.logs.domain.Log;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@RequiredArgsConstructor
+public class CalenderLogDto {
+
+    private final long id;
+    @JsonFormat(pattern = "yyyy년 MM월 dd일")
+    private final LocalDateTime createdTime;
+    private final String level;
+    private final String menu;
+    private final double intake;
+    private final String unit;
+    private final int calorie;
+
+    @Builder
+    private CalenderLogDto(long id,
+                           LocalDateTime createdTime,
+                           Level level,
+                           String menu,
+                           double intake,
+                           String unit,
+                           int calorie) {
+        this.id = id;
+        this.createdTime = createdTime;
+        this.menu = menu;
+        this.intake = intake;
+        this.unit = unit;
+        this.level = level.toString();
+        this.calorie = calorie;
+    }
+
+    public static CalenderLogDto from(Log log) {
+        return CalenderLogDto.builder()
+                .id(log.getId())
+                .createdTime(log.getCreatedTime())
+                .menu(log.getMenu())
+                .intake(log.getIntake())
+                .unit(log.getUnit())
+                .level(log.getLevel())
+                .calorie(log.getCalorie())
+                .build();
+    }
+}

--- a/src/main/java/com/eat/eat_server/domain/logs/repository/LogRepository.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/repository/LogRepository.java
@@ -1,7 +1,10 @@
 package com.eat.eat_server.domain.logs.repository;
 
 import com.eat.eat_server.domain.logs.domain.Log;
+import com.eat.eat_server.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -9,4 +12,6 @@ import java.util.List;
 public interface LogRepository extends JpaRepository<Log, Long> {
 
     List<Log> findBySubCategoryId(long subCategoryId);
+    @Query("SELECT l FROM Log l WHERE l.menu LIKE %:keyword% AND l.subCategory.user = :user")
+    List<Log> findByUserAndMenuKeyword(@Param("user") User user, @Param("keyword") String keyword);
 }

--- a/src/main/java/com/eat/eat_server/domain/logs/service/LogService.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/service/LogService.java
@@ -3,6 +3,7 @@ package com.eat.eat_server.domain.logs.service;
 import com.eat.eat_server.domain.logs.domain.Category;
 import com.eat.eat_server.domain.logs.domain.Log;
 import com.eat.eat_server.domain.logs.domain.SubCategory;
+import com.eat.eat_server.domain.logs.dto.CalenderLogDto;
 import com.eat.eat_server.domain.logs.dto.LogRequestDto;
 import com.eat.eat_server.domain.logs.dto.LogResponseDto;
 import com.eat.eat_server.domain.logs.repository.CategoryRepository;
@@ -51,6 +52,17 @@ public class LogService {
         }
         return logs.stream()
                 .map(LogResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<CalenderLogDto> findCalenderLogs(User user) {
+        List<Log> logs = new ArrayList<>();
+        List<SubCategory> subCategories = subCategoryRepository.findByUser(user);
+        for(SubCategory subCategory:subCategories) {
+            logs.addAll(subCategory.getLogs());
+        }
+        return logs.stream()
+                .map(CalenderLogDto::from)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/eat/eat_server/domain/logs/service/LogService.java
+++ b/src/main/java/com/eat/eat_server/domain/logs/service/LogService.java
@@ -65,4 +65,11 @@ public class LogService {
                 .map(CalenderLogDto::from)
                 .collect(Collectors.toList());
     }
+
+    public List<LogResponseDto> findLogsByMenu(User user, String menu) {
+        List<Log> logs = logRepository.findByUserAndMenuKeyword(user, menu);
+        return logs.stream()
+                .map(LogResponseDto::from)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
- 캘린더 날짜 형식 yyyy년 MM월 DD일로 변경
- 메뉴 키워드 + 로그 생성한 유저 조합으로 로그인한 유저의 특정 메뉴 로그 반환